### PR TITLE
this commit fixes #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,7 +253,7 @@ var FirefoxDriver = {
    */
 
   defaultBinaries: {
-    linux: 'firefox',
+    default: 'firefox',
     darwin: '/Applications/Firefox.app/Contents/MacOS/firefox-bin',
     win32: process.env.ProgramFiles + '\\Mozilla Firefox\\firefox.exe'
   },
@@ -583,7 +583,7 @@ var FirefoxDriver = {
     var platform = process.platform;
     return this.defaultBinaries[platform] ?
       this.defaultBinaries[platform] :
-      which(this.defaultBinaries.linux);
+      which(this.defaultBinaries.default);
   },
 
   /**


### PR DESCRIPTION
When running on linux, it is more safe to use the which command to locate the firefox executable. 

Indeed, 'firefox' is not a valid file path and the call to 'fs.existsSync()' will always fail
