### PR TITLE
Added detection of win64, and added Program Files (x86) as the location ...

### DIFF
--- a/index.js
+++ b/index.js
@@ -256,7 +256,7 @@ var FirefoxDriver = {
     default: 'firefox',
     darwin: '/Applications/Firefox.app/Contents/MacOS/firefox-bin',
     win32: process.env.ProgramFiles + '\\Mozilla Firefox\\firefox.exe'
-	win64: process.env.ProgramFiles + ' (x86)\\Mozilla Firefox\\firefox.exe'
+	win64: process.env["ProgramFiles(x86)"] + '\\Mozilla Firefox\\firefox.exe'
   },
 
   /**


### PR DESCRIPTION
Why: The firefox addon didn't work out of the box because my firefox is not located in C:\Program Files, but rather C:\Program Files (x86). This is a common problem for those running 64-bit windows.

What: Propose adding a win64 entry in the default binaries object, and additional logic in the _getDefaultBinary function to determine if we should use win32 or win64 paths.

How: Checking the platform is win32 and that the process.arc === "x64" should be sufficient in determining the user is on 64-bit windows.

I'm not sure what to do with the browserTypes object that seems to have win32 entries in it. I couldn't find anywhere those were used so I left them untouched. I would imagine we want these to have x64 equivalents too.
